### PR TITLE
Memory optimize voter reg csv

### DIFF
--- a/VoteSquad.py
+++ b/VoteSquad.py
@@ -287,8 +287,10 @@ def get_voter_data(data_file, address_file, county_name, dfMECE, out_shapefile, 
         return(gdfBlocks)
         
     #Othersiwse read in all the voter registration data
+    #load 20,000 rows at a time into an iterator to save memory
     print("  Reading in the voter registration data file...")
-    dfAll = pd.read_csv(data_file,
+
+    dataIterator = pd.read_csv(data_file,
                     usecols=['county_desc','voter_reg_num','res_street_address',
                              'res_city_desc','state_cd','zip_code','precinct_abbrv',
                              'race_code','ethnic_code','gender_code','ncid',
@@ -296,16 +298,17 @@ def get_voter_data(data_file, address_file, county_name, dfMECE, out_shapefile, 
                              'full_phone_number','birth_age','voter_reg_num',
                              'last_name','first_name','middle_name','precinct_abbrv'],
                     sep='\t',
+                    chunksize=20000,
                     encoding = "ISO-8859-1",low_memory=False)
-    
-    #Select records for the provided county name - into a new dataframe
-    print("  Selecting records for {} county...".format(county_name),end='')
-    dfCounty = dfAll[dfAll['county_desc'] == county_name.upper()].reindex()
+
+    #Filter the selected county and then add it to the dfCounty DataFrame
+    print("  Selecting records for {} county...".format(county_name))
+    dfCounty = pd.DataFrame()
+    for chunk in dataIterator:
+        chunk = chunk[chunk['county_desc'] == county_name.upper()]
+        dfCounty = pd.concat([dfCounty,chunk])
     print(" {} records selected".format(dfCounty.shape[0]))
-    
-    #Remove dfAll to free memory
-    del(dfAll)
-    
+
     #Drop the county name from the table and set the voter registration # as index
     print("  Tidying data...")
     dfCounty.drop('county_desc',axis=1,inplace=True)

--- a/VoteSquad.py
+++ b/VoteSquad.py
@@ -285,11 +285,34 @@ def get_voter_data(data_file, address_file, county_name, dfMECE, out_shapefile, 
         print("  Creating geodata dataframe from {}\n  [Be patient...]".format(out_shapefile))
         gdfBlocks = gpd.read_file(out_shapefile)
         return(gdfBlocks)
-        
+
     #Othersiwse read in all the voter registration data
     #load 20,000 rows at a time into an iterator to save memory
     print("  Reading in the voter registration data file...")
 
+    # Expected datatypes for each column
+    dtype = {
+        'county_desc': np.object,
+        'voter_reg_num': np.int64,
+        'last_name': np.object,
+        'first_name': np.object,
+        'middle_name': np.object,
+        'res_street_address': np.object,
+        'res_city_desc': np.object,
+        'state_cd': np.object,
+        'zip_code': np.float64,
+        'mail_addr1': np.object,
+        'mail_city': np.object,
+        'mail_state': np.object,
+        'mail_zipcode': np.object,
+        'full_phone_number': np.object,
+        'race_code': np.object,
+        'ethnic_code': np.object,
+        'gender_code': np.object,
+        'birth_age': np.int64,
+        'precinct_abbrv': np.object,
+        'ncid': np.object
+    }
     dataIterator = pd.read_csv(data_file,
                     usecols=['county_desc','voter_reg_num','res_street_address',
                              'res_city_desc','state_cd','zip_code','precinct_abbrv',
@@ -299,7 +322,8 @@ def get_voter_data(data_file, address_file, county_name, dfMECE, out_shapefile, 
                              'last_name','first_name','middle_name','precinct_abbrv'],
                     sep='\t',
                     chunksize=20000,
-                    encoding = "ISO-8859-1",low_memory=False)
+                    dtype=dtype,
+                    encoding = "ISO-8859-1",low_memory=True)
 
     #Filter the selected county and then add it to the dfCounty DataFrame
     print("  Selecting records for {} county...".format(county_name))


### PR DESCRIPTION
From @joshmaker :

This commit reads 20,000 rows at a time from the voter registration data file to save memory usage. Appears to reduce RAM usage of this function by around 4x, but there may be other memory bottlenecks that aren't impacted by this change.

This change was tested by saving the resulting `dfCounty` data frame to a csv file for both versions and diffing the results.

Loading the data in chunks with the `chunksize` parameter caused subtle changes in the type inference, for example, a column that was an int loaded as a float. Specifying the types ensures that a diff of the resulting county data was exactly the same as the version generated without the `chunksize` parameter. Also, since we manually specify the types, there is no reason not to use the `low_memory` option to further reduce the memory footprint of this operation.

--

We did this because we're hoping to run this as a batch process periodically and decreasing the memory requirements makes that easier.  Hopefully this doesn't inadvertently break anything.  Let us know.

Regards.